### PR TITLE
Update user groups to include 'docker' across multiple playbooks and …

### DIFF
--- a/playbooks/after_format.yaml
+++ b/playbooks/after_format.yaml
@@ -28,7 +28,7 @@
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
       become: true
       become_user: root

--- a/playbooks/container.yaml
+++ b/playbooks/container.yaml
@@ -30,7 +30,7 @@
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
       become: true
       become_user: root

--- a/playbooks/roles/R/README.md
+++ b/playbooks/roles/R/README.md
@@ -37,7 +37,7 @@ Example Playbook
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/aws/molecule/default/converge.yml
+++ b/playbooks/roles/aws/molecule/default/converge.yml
@@ -15,7 +15,7 @@
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: aws
       become: yes

--- a/playbooks/roles/dotfiles/README.md
+++ b/playbooks/roles/dotfiles/README.md
@@ -37,7 +37,7 @@ Example Playbook
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/dotfiles/molecule/default/converge.yml
+++ b/playbooks/roles/dotfiles/molecule/default/converge.yml
@@ -18,7 +18,7 @@
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/env_setup/README.md
+++ b/playbooks/roles/env_setup/README.md
@@ -37,7 +37,7 @@ Example Playbook
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/env_setup/molecule/default/converge.yml
+++ b/playbooks/roles/env_setup/molecule/default/converge.yml
@@ -17,7 +17,7 @@
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/python/README.md
+++ b/playbooks/roles/python/README.md
@@ -37,7 +37,7 @@ Example Playbook
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/repos/README.md
+++ b/playbooks/roles/repos/README.md
@@ -37,7 +37,7 @@ Example Playbook
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/repos/molecule/default/converge.yml
+++ b/playbooks/roles/repos/molecule/default/converge.yml
@@ -15,7 +15,7 @@
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/shell/README.md
+++ b/playbooks/roles/shell/README.md
@@ -37,7 +37,7 @@ Example Playbook
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/shell/molecule/default/converge.yml
+++ b/playbooks/roles/shell/molecule/default/converge.yml
@@ -17,7 +17,7 @@
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/ssh/README.md
+++ b/playbooks/roles/ssh/README.md
@@ -88,7 +88,7 @@ Example Playbook
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/ssh/molecule/default/converge.yml
+++ b/playbooks/roles/ssh/molecule/default/converge.yml
@@ -15,7 +15,7 @@
             uid: 1001
             shell: /bin/bash
             comment: "Aleph User"
-            groups: "admin,sudo"
+            groups: "admin,sudo,docker"
             password: ""
     - role: ssh
       become: yes

--- a/playbooks/roles/users/molecule/default/verify.yml
+++ b/playbooks/roles/users/molecule/default/verify.yml
@@ -31,6 +31,7 @@
         that:
           - "'admin' in aleph_groups.stdout.split()"
           - "'sudo' in aleph_groups.stdout.split()"
+          - "'docker' in aleph_groups.stdout.split()"
     
     - name: Check Aleph's sudo access
       ansible.builtin.command: sudo -lU aleph

--- a/playbooks/roles/users/vars/main.yml
+++ b/playbooks/roles/users/vars/main.yml
@@ -4,10 +4,11 @@ users:
     uid: 1001
     shell: /bin/bash
     comment: "Aleph User"
-    groups: "admin,sudo"
+    groups: "admin,sudo,docker"
     password: ""
 
 required_groups:
   - admin
   - users
   - sudo
+  - docker


### PR DESCRIPTION
…roles

- Modified user group assignments in various YAML files to add 'docker' to the existing 'admin' and 'sudo' groups for the Aleph User.
- Ensured consistency across playbooks, roles, and README documentation to reflect this change.