### PR TITLE
Add zsh-autoenv plugin for automatic environment variable loading

### DIFF
--- a/ISSUE_6_SOLUTION.md
+++ b/ISSUE_6_SOLUTION.md
@@ -1,0 +1,219 @@
+# Solution for Issue #6: Auto Load Environment Variables from Folders
+
+## Problem Statement
+
+Environment variables from `.env` files were not automatically loaded when entering directories in zsh, requiring manual `source .env` commands each time.
+
+## Solution Implemented
+
+The solution implements the `zsh-autoenv` plugin as suggested in the original issue. This plugin automatically sources `.env` files when you navigate into directories containing them.
+
+## Changes Made
+
+### 1. Updated Ansible Roles
+
+Modified both `shell` and `env_setup` roles to include zsh-autoenv setup:
+
+**Files Modified:**
+- `/home/fer/ansible/playbooks/roles/shell/tasks/main.yml`
+- `/home/fer/ansible/playbooks/roles/env_setup/tasks/main.yml`
+
+**Changes:**
+- Added task to check if zsh-autoenv is installed
+- Added task to clone zsh-autoenv from GitHub repository
+- Added task to configure zsh-autoenv in `.zshrc`
+- Configuration includes:
+  - Sourcing the autoenv.zsh script
+  - Setting `AUTOENV_FILE_ENTER=.env`
+  - Setting `AUTOENV_FILE_LEAVE=.env.leave`
+  - Setting `AUTOENV_LOOK_UPWARDS=1` to search parent directories
+
+### 2. Updated Documentation
+
+**Files Modified:**
+- `/home/fer/ansible/playbooks/roles/shell/README.md`
+- `/home/fer/ansible/playbooks/roles/env_setup/README.md`
+
+Added comprehensive features section describing:
+- zsh setup
+- oh-my-zsh installation
+- zsh-autosuggestions plugin
+- **zsh-autoenv plugin** (NEW)
+
+### 3. Enhanced Testing
+
+**Files Modified:**
+- `/home/fer/ansible/playbooks/roles/shell/molecule/default/verify.yml`
+- `/home/fer/ansible/playbooks/roles/env_setup/molecule/default/verify.yml`
+
+Added verification tests for:
+- zsh-autoenv plugin directory existence
+- zsh-autoenv configuration in `.zshrc`
+
+### 4. Created User Guide
+
+**Files Created:**
+- `/home/fer/ansible/ZSH_AUTOENV_GUIDE.md`
+
+Comprehensive guide covering:
+- Plugin overview
+- Configuration details
+- Usage examples
+- Security considerations
+- Troubleshooting tips
+
+## How It Works
+
+1. When the Ansible playbook runs, it:
+   - Clones zsh-autoenv into `~/.oh-my-zsh/custom/plugins/zsh-autoenv`
+   - Adds configuration to `~/.zshrc` using an Ansible managed block
+
+2. When you enter a directory with a `.env` file:
+   - zsh-autoenv detects the file
+   - On first encounter, prompts for authorization (security feature)
+   - After authorization, automatically sources the file
+   - Variables become available in your shell
+
+3. When you leave the directory:
+   - If a `.env.leave` file exists, it's automatically sourced
+   - Useful for unsetting variables
+
+## Testing the Solution
+
+### Automated Testing (Molecule)
+
+Run molecule tests for the roles:
+
+```bash
+# Test shell role
+cd playbooks/roles/shell
+molecule test
+
+# Test env_setup role
+cd playbooks/roles/env_setup
+molecule test
+```
+
+### Manual Testing
+
+1. **Run the playbook:**
+   ```bash
+   ansible-playbook playbooks/after_format.yaml --tags core
+   ```
+
+2. **Test the functionality:**
+   ```bash
+   # Create test directory
+   mkdir ~/test_env && cd ~/test_env
+   
+   # Create .env file
+   echo 'export API_URL=http://example.com' > .env
+   
+   # Exit and re-enter directory
+   cd ..
+   cd test_env  # zsh-autoenv will prompt for authorization
+   
+   # Verify variable is loaded
+   echo $API_URL  # Should output: http://example.com
+   ```
+
+3. **Test cleanup on directory exit:**
+   ```bash
+   # Create .env.leave file
+   echo 'unset API_URL' > .env.leave
+   
+   # Exit directory
+   cd ..
+   
+   # Verify variable is unset
+   echo $API_URL  # Should be empty
+   ```
+
+## Verification Steps
+
+After running the playbook, verify the installation:
+
+```bash
+# 1. Check plugin is installed
+ls -la ~/.oh-my-zsh/custom/plugins/zsh-autoenv
+
+# 2. Check configuration in .zshrc
+grep -A 5 "ANSIBLE MANAGED BLOCK - ZSH AUTOENV" ~/.zshrc
+
+# 3. Check zsh-autoenv is sourced
+grep "autoenv.zsh" ~/.zshrc
+
+# 4. Restart shell or source .zshrc
+source ~/.zshrc
+```
+
+## Playbooks Affected
+
+The following playbooks will automatically include this fix:
+
+1. **`playbooks/after_format.yaml`** - Main setup playbook
+2. **`playbooks/container.yaml`** - Container setup playbook
+
+Both use the `env_setup` role which now includes zsh-autoenv.
+
+## Security Features
+
+zsh-autoenv includes important security features:
+
+1. **Authorization Required**: First time encountering a `.env` file, user must explicitly authorize it
+2. **Content Preview**: Shows file contents before authorization
+3. **Change Detection**: If a `.env` file changes, re-authorization is required
+4. **Authorized Files List**: Maintains list at `~/.autoenv_authorized`
+
+## Additional Configuration Options
+
+Users can customize zsh-autoenv by modifying these variables in their `.zshrc`:
+
+```bash
+# Change the filename to look for
+export AUTOENV_FILE_ENTER=.autoenv
+
+# Disable looking in parent directories
+export AUTOENV_LOOK_UPWARDS=0
+
+# Change leave file name
+export AUTOENV_FILE_LEAVE=.autoenv_leave
+```
+
+## References
+
+- Original Issue: [Issue #6](https://github.com/gonzfe05/ansible/issues/6)
+- zsh-autoenv GitHub: [Tarrasch/zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv)
+- User Guide: `ZSH_AUTOENV_GUIDE.md`
+
+## Benefits
+
+✅ No more manually running `source .env` when entering project directories
+✅ Automatic environment isolation per project
+✅ Security-first approach with authorization prompts
+✅ Seamless integration with existing zsh setup
+✅ Support for cleanup on directory exit
+✅ Parent directory lookup for shared configs
+
+## Rollout Plan
+
+1. ✅ Implement solution in `shell` and `env_setup` roles
+2. ✅ Add comprehensive testing
+3. ✅ Update documentation
+4. ✅ Create user guide
+5. ⏳ Test with molecule
+6. ⏳ Deploy to test environment
+7. ⏳ Get user feedback
+8. ⏳ Merge to main branch
+9. ⏳ Close Issue #6
+
+## Future Enhancements
+
+Potential improvements for future iterations:
+
+- Add role variable to enable/disable zsh-autoenv
+- Add support for custom file names via role variables
+- Create example `.env` templates
+- Add integration with vault for secure credential management
+- Create helper script to quickly authorize all `.env` files in a directory tree
+

--- a/ZSH_AUTOENV_GUIDE.md
+++ b/ZSH_AUTOENV_GUIDE.md
@@ -1,0 +1,188 @@
+# Zsh-Autoenv Setup and Usage Guide
+
+## Overview
+
+This repository now includes automatic setup of the `zsh-autoenv` plugin, which automatically loads environment variables from `.env` files when you enter a directory. This solves the issue described in [Issue #6](https://github.com/gonzfe05/ansible/issues/6).
+
+## What is zsh-autoenv?
+
+`zsh-autoenv` is a Zsh plugin that automatically sources `.env` files when you navigate into a directory containing them. This eliminates the need to manually run `source .env` each time you enter a project directory.
+
+## How it Works
+
+The Ansible roles (`shell` and `env_setup`) now automatically:
+
+1. Clone the `zsh-autoenv` plugin from GitHub into `~/.oh-my-zsh/custom/plugins/zsh-autoenv`
+2. Configure your `.zshrc` file to source and enable the plugin
+3. Set appropriate environment variables for plugin configuration
+
+## Configuration Details
+
+The following configuration is automatically added to your `.zshrc`:
+
+```bash
+# Enable zsh-autoenv plugin for automatic .env file loading
+source ~/.oh-my-zsh/custom/plugins/zsh-autoenv/autoenv.zsh
+
+# zsh-autoenv settings
+export AUTOENV_FILE_ENTER=.env
+export AUTOENV_FILE_LEAVE=.env.leave
+export AUTOENV_LOOK_UPWARDS=1
+```
+
+### Configuration Options
+
+- **AUTOENV_FILE_ENTER**: The filename to look for when entering a directory (default: `.env`)
+- **AUTOENV_FILE_LEAVE**: The filename to source when leaving a directory (default: `.env.leave`)
+- **AUTOENV_LOOK_UPWARDS**: Look for `.env` files in parent directories (1 = enabled)
+
+## Usage Examples
+
+### Basic Usage
+
+1. Create a directory with a `.env` file:
+
+```bash
+mkdir myproject
+cd myproject
+echo 'export API_URL=http://example.com' > .env
+echo 'export API_KEY=your_secret_key' > .env
+```
+
+2. The first time you enter the directory, `zsh-autoenv` will ask for confirmation:
+
+```
+Attempting to load unauthorized env file!
+-rw-r--r-- 1 user user 48 Oct 18 10:00 /home/user/myproject/.env
+
+**********************************************
+
+export API_URL=http://example.com
+export API_KEY=your_secret_key
+
+**********************************************
+
+Would you like to authorize it? (type 'yes') yes
+```
+
+3. After authorization, the environment variables will be loaded automatically every time you `cd` into that directory:
+
+```bash
+cd myproject
+echo $API_URL  # outputs: http://example.com
+```
+
+### Using .env.leave Files
+
+You can also create a `.env.leave` file to unset variables when leaving a directory:
+
+```bash
+# In myproject/.env.leave
+unset API_URL
+unset API_KEY
+```
+
+Now when you leave the directory, these variables will be automatically unset:
+
+```bash
+cd myproject
+echo $API_URL  # outputs: http://example.com
+cd ..
+echo $API_URL  # outputs: (empty)
+```
+
+### Security Considerations
+
+- `zsh-autoenv` will ask for confirmation the first time it encounters a new `.env` file
+- Authorized files are stored in `~/.autoenv_authorized`
+- If a `.env` file changes, you'll be prompted to re-authorize it
+- Never authorize `.env` files from untrusted sources
+
+## Testing the Setup
+
+After running the Ansible playbook, you can test the setup with these steps:
+
+1. Open a new terminal or source your `.zshrc`:
+```bash
+source ~/.zshrc
+```
+
+2. Verify the plugin is installed:
+```bash
+ls -la ~/.oh-my-zsh/custom/plugins/zsh-autoenv
+```
+
+3. Test with a sample project:
+```bash
+mkdir ~/test_autoenv
+cd ~/test_autoenv
+echo 'export TEST_VAR=hello_world' > .env
+cd ~/test_autoenv  # zsh-autoenv will prompt for authorization
+echo $TEST_VAR     # Should output: hello_world
+```
+
+## Running the Playbook
+
+To apply this configuration, run the playbook that includes either the `shell` or `env_setup` role:
+
+```bash
+ansible-playbook playbooks/after_format.yaml
+```
+
+Or test with molecule:
+
+```bash
+cd playbooks/roles/shell
+molecule test
+```
+
+## Troubleshooting
+
+### Plugin not working
+
+1. Check if the plugin is installed:
+```bash
+ls ~/.oh-my-zsh/custom/plugins/zsh-autoenv
+```
+
+2. Check if it's configured in `.zshrc`:
+```bash
+grep autoenv ~/.zshrc
+```
+
+3. Make sure you're using zsh:
+```bash
+echo $SHELL
+```
+
+### Permission issues
+
+If you see permission errors, ensure the `.env` files have appropriate permissions:
+```bash
+chmod 644 .env
+```
+
+### Variables not loading
+
+1. Check if the `.env` file is authorized:
+```bash
+cat ~/.autoenv_authorized
+```
+
+2. Try re-authorizing by removing the entry and re-entering the directory:
+```bash
+# Edit ~/.autoenv_authorized and remove the line for your .env file
+cd /path/to/your/project
+```
+
+## Additional Resources
+
+- [zsh-autoenv GitHub Repository](https://github.com/Tarrasch/zsh-autoenv)
+- [Original Issue #6](https://github.com/gonzfe05/ansible/issues/6)
+
+## Related Roles
+
+- `shell` - Sets up zsh with oh-my-zsh and plugins including zsh-autoenv
+- `env_setup` - Alternative role with the same functionality
+- `dotfiles` - Manages dotfiles using GNU Stow
+

--- a/playbooks/roles/env_setup/README.md
+++ b/playbooks/roles/env_setup/README.md
@@ -1,7 +1,17 @@
 Role Name
 =========
 
-Custom environment configs, mainly zsh as default shell
+Custom environment configs, mainly zsh as default shell with automatic .env file loading
+
+Features
+--------
+
+- Sets zsh as the default shell
+- Installs and configures Oh-My-Zsh
+- Installs zsh-autosuggestions plugin
+- Installs and configures zsh-autoenv plugin for automatic loading of .env files
+
+The zsh-autoenv plugin automatically sources `.env` files when you enter a directory and can optionally source `.env.leave` files when you exit. This eliminates the need to manually run `source .env` each time you enter a project directory.
 
 Requirements
 ------------
@@ -10,6 +20,7 @@ ansible
 molecule[docker]
 ansible-lint
 zsh
+git
 
 Dependencies
 ------------

--- a/playbooks/roles/env_setup/molecule/default/verify.yml
+++ b/playbooks/roles/env_setup/molecule/default/verify.yml
@@ -44,3 +44,26 @@
         that:
           - zsh_autosuggestions_check.stat.exists
         msg: "zsh-autosuggestions plugin is missing"
+
+    - name: Verify zsh-autoenv plugin directory exists
+      stat:
+        path: "{{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autoenv"
+      register: zsh_autoenv_check
+
+    - name: Assert zsh-autoenv plugin is installed
+      ansible.builtin.assert:
+        that:
+          - zsh_autoenv_check.stat.exists
+        msg: "zsh-autoenv plugin is missing"
+
+    - name: Verify zsh-autoenv configuration in .zshrc
+      command: grep -q "zsh-autoenv/autoenv.zsh" "{{ ansible_env.HOME }}/.zshrc"
+      register: zshrc_autoenv_check
+      changed_when: false
+      failed_when: false
+
+    - name: Assert zsh-autoenv is configured in .zshrc
+      ansible.builtin.assert:
+        that:
+          - zshrc_autoenv_check.rc == 0
+        msg: "zsh-autoenv is not configured in .zshrc"

--- a/playbooks/roles/env_setup/tasks/main.yml
+++ b/playbooks/roles/env_setup/tasks/main.yml
@@ -73,3 +73,35 @@
     repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
     dest: "{{ ansible_env.HOME }}/.oh-my-zsh/plugins/zsh-autosuggestions"
     version: master
+
+- name: Check if zsh-autoenv is installed
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autoenv"
+  register: zsh_autoenv_stats
+
+- name: Install zsh-autoenv
+  when: not zsh_autoenv_stats.stat.exists
+  ansible.builtin.git:
+    repo: 'https://github.com/Tarrasch/zsh-autoenv.git'
+    dest: "{{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autoenv"
+    version: master
+
+- name: Check if .zshrc exists
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+  register: zshrc_stat
+
+- name: Configure zsh-autoenv in .zshrc
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    block: |
+      # Enable zsh-autoenv plugin for automatic .env file loading
+      source {{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autoenv/autoenv.zsh
+      
+      # zsh-autoenv settings
+      export AUTOENV_FILE_ENTER=.env
+      export AUTOENV_FILE_LEAVE=.env.leave
+      export AUTOENV_LOOK_UPWARDS=1
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - ZSH AUTOENV"
+    create: yes
+  when: zshrc_stat.stat.exists

--- a/playbooks/roles/shell/README.md
+++ b/playbooks/roles/shell/README.md
@@ -1,7 +1,17 @@
 Role Name
 =========
 
-Custom environment configs, mainly zsh as default shell
+Custom environment configs, mainly zsh as default shell with automatic .env file loading
+
+Features
+--------
+
+- Sets zsh as the default shell
+- Installs and configures Oh-My-Zsh
+- Installs zsh-autosuggestions plugin
+- Installs and configures zsh-autoenv plugin for automatic loading of .env files
+
+The zsh-autoenv plugin automatically sources `.env` files when you enter a directory and can optionally source `.env.leave` files when you exit. This eliminates the need to manually run `source .env` each time you enter a project directory.
 
 Requirements
 ------------
@@ -10,6 +20,7 @@ ansible
 molecule[docker]
 ansible-lint
 zsh
+git
 
 Dependencies
 ------------

--- a/playbooks/roles/shell/molecule/default/verify.yml
+++ b/playbooks/roles/shell/molecule/default/verify.yml
@@ -44,3 +44,26 @@
         that:
           - zsh_autosuggestions_check.stat.exists
         msg: "zsh-autosuggestions plugin is missing"
+
+    - name: Verify zsh-autoenv plugin directory exists
+      stat:
+        path: "{{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autoenv"
+      register: zsh_autoenv_check
+
+    - name: Assert zsh-autoenv plugin is installed
+      ansible.builtin.assert:
+        that:
+          - zsh_autoenv_check.stat.exists
+        msg: "zsh-autoenv plugin is missing"
+
+    - name: Verify zsh-autoenv configuration in .zshrc
+      command: grep -q "zsh-autoenv/autoenv.zsh" "{{ ansible_env.HOME }}/.zshrc"
+      register: zshrc_autoenv_check
+      changed_when: false
+      failed_when: false
+
+    - name: Assert zsh-autoenv is configured in .zshrc
+      ansible.builtin.assert:
+        that:
+          - zshrc_autoenv_check.rc == 0
+        msg: "zsh-autoenv is not configured in .zshrc"

--- a/playbooks/roles/shell/tasks/main.yml
+++ b/playbooks/roles/shell/tasks/main.yml
@@ -73,3 +73,35 @@
     repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
     dest: "{{ ansible_env.HOME }}/.oh-my-zsh/plugins/zsh-autosuggestions"
     version: master
+
+- name: Check if zsh-autoenv is installed
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autoenv"
+  register: zsh_autoenv_stats
+
+- name: Install zsh-autoenv
+  when: not zsh_autoenv_stats.stat.exists
+  ansible.builtin.git:
+    repo: 'https://github.com/Tarrasch/zsh-autoenv.git'
+    dest: "{{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autoenv"
+    version: master
+
+- name: Check if .zshrc exists
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+  register: zshrc_stat
+
+- name: Configure zsh-autoenv in .zshrc
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    block: |
+      # Enable zsh-autoenv plugin for automatic .env file loading
+      source {{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autoenv/autoenv.zsh
+      
+      # zsh-autoenv settings
+      export AUTOENV_FILE_ENTER=.env
+      export AUTOENV_FILE_LEAVE=.env.leave
+      export AUTOENV_LOOK_UPWARDS=1
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - ZSH AUTOENV"
+    create: yes
+  when: zshrc_stat.stat.exists


### PR DESCRIPTION
- Implemented the zsh-autoenv plugin to automatically source .env files when entering directories, eliminating the need for manual sourcing.
- Updated Ansible roles (shell and env_setup) to install and configure zsh-autoenv, including necessary tasks in .zshrc.
- Enhanced documentation with a comprehensive user guide and updated README files to reflect new features.
- Added verification tests to ensure proper installation and configuration of the zsh-autoenv plugin.