### PR TITLE
Add ngrok role to after_format playbook

### DIFF
--- a/playbooks/after_format.yaml
+++ b/playbooks/after_format.yaml
@@ -81,4 +81,8 @@
       become: true
       become_user: aleph
       tags: ['astro']
+    - role: ngrok
+      become: true
+      become_user: aleph
+      tags: ['ngrok']
 


### PR DESCRIPTION
- Included ngrok role in the after_format.yaml playbook for SSH tunneling.
- Configured role to run with elevated privileges under the 'aleph' user.
- Tagged the role for easier execution and management.