### PR TITLE
Add X11 authorization role and clipboard integration

### DIFF
--- a/ISSUE_3_X11_CLIPBOARD_FIX.md
+++ b/ISSUE_3_X11_CLIPBOARD_FIX.md
@@ -1,0 +1,312 @@
+# Fix for Issue #3: X11 Authorization and Clipboard Access
+
+**Issue**: [#3 - aleph user doesn't have permission for X server](https://github.com/gonzfe05/ansible/issues/3)
+
+**Problem**: When switching to the `aleph` user (or any secondary user), GUI applications and clipboard operations fail with authorization errors.
+
+**Symptoms**:
+- `xclip` fails with: "Authorization required, but no authorization protocol specified" and "Can't open display"
+- Vim clipboard operations (`"+y` or with `clipboard=unnamedplus`) don't work
+- VSCode and other GUI apps won't launch
+- Error: "Missing X server or $DISPLAY"
+
+## Root Cause
+
+When you switch users with `sudo su aleph` or similar, the new user session doesn't have permission to access the X server of the original graphical session. The X server uses authentication to prevent unauthorized access to the display.
+
+## Solution Implemented
+
+This repository now includes a comprehensive fix with three components:
+
+### 1. X11 Authorization Role (`playbooks/roles/x11_auth`)
+
+A new Ansible role that:
+- Grants X server access to specified users using `xhost +si:localuser:<username>`
+- Creates persistent configuration via `/etc/profile.d/x11-auth-secondary-users.sh`
+- Sets up a systemd user service as an alternative startup method
+- Runs immediately during playbook execution
+
+**Location**: `playbooks/roles/x11_auth/`
+
+### 2. Vim Clipboard Configuration (`env_setup` role)
+
+Automatic configuration of Vim/Neovim clipboard integration:
+- Adds `set clipboard=unnamedplus` to `~/.vimrc`
+- Configures Ctrl+C/V mappings for system clipboard
+- Supports both Vim and Neovim
+
+**Location**: `playbooks/roles/env_setup/tasks/main.yml`
+
+### 3. Required Packages
+
+The playbook now installs:
+- `vim-gtk3` - Vim compiled with clipboard support (+clipboard)
+- `xclip` - Clipboard utilities for X11
+- `wl-clipboard` - Clipboard utilities for Wayland
+
+**Location**: `playbooks/after_format.yaml`
+
+## How to Use
+
+### Automatic Installation
+
+When you run the playbook, everything is configured automatically:
+
+```bash
+make run_local
+# OR
+ansible-playbook playbooks/after_format.yaml --ask-become-pass
+```
+
+The `x11_auth` role is part of the core setup and will:
+1. Grant immediate X server access to the `aleph` user
+2. Configure persistent startup scripts
+3. Set up Vim clipboard integration
+
+### Manual Application (If Needed)
+
+If you're experiencing the issue right now, run this immediately:
+
+```bash
+# From your graphical session user (not aleph)
+xhost +si:localuser:aleph
+```
+
+Then as `aleph`:
+```bash
+# Verify DISPLAY is set
+echo $DISPLAY  # Should show :0 or :1
+
+# Test clipboard
+echo test | xclip -selection clipboard
+xclip -o -selection clipboard
+
+# Test in Vim
+vim
+# Press: i
+# Type some text
+# Press: Esc
+# Press: V (visual line mode)
+# Press: y (yank/copy)
+# The text should now be in your system clipboard
+```
+
+### For Persistent Configuration
+
+The playbook creates `/etc/profile.d/x11-auth-secondary-users.sh` which runs automatically on login. To make it take effect:
+
+1. **Option A**: Log out and log back in to your graphical session
+2. **Option B**: Source the script manually:
+   ```bash
+   source /etc/profile.d/x11-auth-secondary-users.sh
+   ```
+
+## Verification Steps
+
+### 1. Check Vim Clipboard Support
+```bash
+vim --version | grep clipboard
+```
+Should show `+clipboard` and `+xterm_clipboard` (not `-clipboard`).
+
+### 2. Check DISPLAY Environment
+```bash
+# As aleph user
+echo $DISPLAY
+```
+Should show something like `:0` or `:1`, not empty.
+
+### 3. Test X Server Access
+```bash
+# As aleph user
+xhost
+```
+Should list allowed connections including `localuser:aleph`.
+
+### 4. Test Clipboard Tools
+```bash
+# As aleph user
+echo "test message" | xclip -selection clipboard
+xclip -o -selection clipboard
+```
+Should output "test message".
+
+### 5. Test Vim Clipboard
+```bash
+# As aleph user
+vim
+```
+In Vim:
+1. Type: `:set clipboard?` - should show `clipboard=unnamedplus`
+2. Visual select text and press `y`
+3. Switch to another app and paste (Ctrl+V) - should paste the Vim text
+
+## Troubleshooting
+
+### Still Getting Authorization Errors?
+
+1. **Ensure you're in a graphical session**:
+   ```bash
+   echo $DISPLAY
+   ```
+   If empty, open a terminal within your desktop environment.
+
+2. **Manually grant access**:
+   ```bash
+   # As the graphical session owner
+   xhost +si:localuser:aleph
+   ```
+
+3. **Check the script exists**:
+   ```bash
+   cat /etc/profile.d/x11-auth-secondary-users.sh
+   ```
+
+4. **Log out and back in**: The persistent configuration activates on graphical session start.
+
+### Vim Still Not Copying to Clipboard?
+
+1. **Verify Vim has clipboard support**:
+   ```bash
+   vim --version | grep +clipboard
+   ```
+   If it shows `-clipboard`, you need `vim-gtk3`:
+   ```bash
+   sudo apt-get install -y vim-gtk3
+   sudo update-alternatives --config vim  # Select vim.gtk3
+   ```
+
+2. **Check .vimrc configuration**:
+   ```bash
+   grep clipboard ~/.vimrc
+   ```
+   Should contain `set clipboard=unnamedplus`.
+
+3. **Source the vimrc**:
+   ```vim
+   :source ~/.vimrc
+   ```
+   Or restart Vim.
+
+4. **Try explicit clipboard register**:
+   In Vim, select text and press `"+y` instead of just `y`.
+
+### In tmux?
+
+Add to `~/.tmux.conf`:
+```tmux
+set -g set-clipboard on
+```
+Then reload tmux config or restart tmux.
+
+### On Wayland?
+
+Ensure `wl-clipboard` is installed:
+```bash
+sudo apt-get install -y wl-clipboard
+```
+
+Test with:
+```bash
+echo test | wl-copy
+wl-paste
+```
+
+### SSH Session?
+
+If you're SSH'ing as aleph:
+- Use X11 forwarding: `ssh -X aleph@hostname`
+- OR use the terminal on the local desktop instead
+
+## Files Modified/Created
+
+### New Role
+- `playbooks/roles/x11_auth/` - Complete new role for X11 authorization
+  - `tasks/main.yml` - Main automation tasks
+  - `defaults/main.yml` - Default variables
+  - `templates/x11-auth-secondary-users.sh.j2` - Startup script template
+  - `templates/x11-auth.service.j2` - Systemd service template
+  - `README.md` - Role documentation
+  - `meta/main.yml` - Role metadata
+  - `molecule/` - Testing configuration
+
+### Modified Files
+- `playbooks/after_format.yaml` - Added x11_auth role to core setup
+- `playbooks/after_format.yaml` - Added wl-clipboard package
+- `playbooks/roles/env_setup/tasks/main.yml` - Added Vim/Neovim clipboard configuration
+
+### Created at Runtime
+- `/etc/profile.d/x11-auth-secondary-users.sh` - Auto-run on login
+- `~/.config/systemd/user/x11-auth.service` - Alternative systemd service
+- `~/.vimrc` - Clipboard configuration (ANSIBLE MANAGED BLOCK)
+
+## Technical Details
+
+### Why `xhost +si:localuser:aleph`?
+
+This command grants X server access specifically to the local user `aleph`. It's secure because:
+- `si:localuser:` restricts access to local users only (not network)
+- It doesn't use the insecure `xhost +` (which allows anyone)
+- It's limited to specific usernames
+
+### Alternative: XAUTHORITY Sharing
+
+Another approach is sharing the `~/.Xauthority` file, but this is more complex and less secure. The `xhost` method is simpler and sufficient for local user switching.
+
+### Wayland Considerations
+
+Modern Ubuntu uses Wayland by default, but it runs XWayland for X11 compatibility. The `xhost` command still works through XWayland, and `wl-clipboard` provides native Wayland clipboard access.
+
+## Related Issues
+
+- [Issue #3: aleph user doesn't have permission for X server](https://github.com/gonzfe05/ansible/issues/3)
+
+## Testing
+
+To test the new role in isolation:
+
+```bash
+cd playbooks/roles/x11_auth
+molecule test
+```
+
+To test the full playbook in a VM:
+
+```bash
+make test-vm-core
+```
+
+## Security Considerations
+
+The `xhost +si:localuser:<username>` method is secure for local user switching because:
+1. Only specific local users are granted access (not network)
+2. It requires physical or local SSH access to the machine
+3. The user must already have sudo/system access to switch users
+4. It doesn't compromise the X server security model
+
+For production environments with stricter security requirements, consider:
+- Using separate graphical sessions per user
+- Implementing PolicyKit rules for specific GUI applications
+- Using containerization or virtualization for isolation
+
+## Future Improvements
+
+Potential enhancements:
+- [ ] Auto-detect all sudo users and grant access
+- [ ] Add option to use XAUTHORITY sharing instead
+- [ ] Support for multiple display servers
+- [ ] Integration with display manager (GDM/LightDM) configuration
+- [ ] Automated testing in graphical VM environment
+
+## References
+
+- [Xhost Manual](https://www.x.org/releases/X11R7.7/doc/man/man1/xhost.1.xhtml)
+- [Vim Clipboard Documentation](https://vimhelp.org/options.txt.html#%27clipboard%27)
+- [X11 Security](https://www.x.org/releases/X11R7.6/doc/xorg-docs/security/security.html)
+
+---
+
+**Status**: ✅ Fixed in playbook  
+**Last Updated**: 2025-10-21  
+**Author**: gonzfe05
+

--- a/README.md
+++ b/README.md
@@ -212,8 +212,28 @@ Each role has its own README:
 - [REMOTE_SSH_SETUP.md](playbooks/REMOTE_SSH_SETUP.md) - SSH server setup guide
 - [ZSH_AUTOENV_GUIDE.md](ZSH_AUTOENV_GUIDE.md) - Zsh autoenv guide
 - [SSH_AGENT_FIX_SUMMARY.md](SSH_AGENT_FIX_SUMMARY.md) - SSH agent troubleshooting
+- [ISSUE_3_X11_CLIPBOARD_FIX.md](ISSUE_3_X11_CLIPBOARD_FIX.md) - X11 authorization and clipboard fix
 
 ## Troubleshooting
+
+### X11 Authorization and Clipboard Issues
+
+**Problem**: When switching to the `aleph` user, clipboard operations fail or GUI apps won't launch.
+
+**Symptoms**:
+- Vim clipboard (`v` + `y`) doesn't copy to system clipboard
+- `xclip` fails with "Authorization required" or "Can't open display"
+- VSCode won't launch with "Missing X server" error
+
+**Solution**: This is now automatically fixed by the `x11_auth` role in the playbook.
+
+**Manual fix** (if needed immediately):
+```bash
+# As the graphical session owner (not aleph)
+xhost +si:localuser:aleph
+```
+
+See [ISSUE_3_X11_CLIPBOARD_FIX.md](ISSUE_3_X11_CLIPBOARD_FIX.md) for complete details.
 
 ### SSH Role Issues
 

--- a/playbooks/after_format.yaml
+++ b/playbooks/after_format.yaml
@@ -14,8 +14,9 @@
           - fzf
           - zip
           - vim
-          - xclip
-          - vim-gtk3
+          - xclip                # Clipboard support for X11
+          - wl-clipboard         # Clipboard support for Wayland
+          - vim-gtk3             # Vim with clipboard support
           - sudo
             #- clang-12
           - build-essential
@@ -33,6 +34,12 @@
             password: ""
       become: true
       become_user: root
+      tags: ['core']
+    - role: x11_auth
+      vars:
+        x11_auth_users:
+          - aleph
+      become: true
       tags: ['core']
     - role: ssh
       # vars:

--- a/playbooks/roles/env_setup/tasks/main.yml
+++ b/playbooks/roles/env_setup/tasks/main.yml
@@ -108,3 +108,35 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK - ZSH AUTOENV"
     create: yes
   when: zshrc_stat.stat.exists
+
+- name: Configure Vim clipboard integration in .vimrc
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.vimrc"
+    block: |
+      " Enable system clipboard integration
+      " This allows yanking with 'y' to copy to system clipboard
+      " and pasting with 'p' to paste from system clipboard
+      set clipboard=unnamedplus
+      
+      " Ensure we're using vim-gtk or similar with +clipboard support
+      if has('clipboard')
+        " Explicit mappings for system clipboard
+        vnoremap <C-c> "+y
+        vnoremap <C-x> "+x
+        nnoremap <C-v> "+p
+        inoremap <C-v> <C-r>+
+      endif
+    marker: '" {mark} ANSIBLE MANAGED BLOCK - CLIPBOARD'
+    create: yes
+
+- name: Configure Neovim clipboard integration if init.vim exists
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.config/nvim/init.vim"
+    block: |
+      " Enable system clipboard integration
+      set clipboard=unnamedplus
+      
+      " Neovim automatically detects clipboard providers (xclip, wl-clipboard, etc.)
+    marker: '" {mark} ANSIBLE MANAGED BLOCK - CLIPBOARD'
+    create: no
+  ignore_errors: true

--- a/playbooks/roles/x11_auth/QUICK_START.md
+++ b/playbooks/roles/x11_auth/QUICK_START.md
@@ -1,0 +1,61 @@
+# X11 Auth Role - Quick Start
+
+## Immediate Fix (Manual)
+
+If you're experiencing X11 authorization issues right now:
+
+```bash
+# Run from your graphical session user (NOT as aleph)
+xhost +si:localuser:aleph
+```
+
+Then test as aleph:
+```bash
+sudo su - aleph
+echo test | xclip -selection clipboard
+xclip -o -selection clipboard
+```
+
+## Automatic Fix (via Playbook)
+
+This role is automatically included in `after_format.yaml`. Just run:
+
+```bash
+make run_local
+```
+
+## What Gets Fixed
+
+1. ✅ X server access for `aleph` user
+2. ✅ Clipboard operations (xclip/wl-clipboard)
+3. ✅ Vim clipboard integration (`set clipboard=unnamedplus`)
+4. ✅ GUI apps launching from secondary user
+5. ✅ Persistent configuration on reboot
+
+## Verification
+
+After running the playbook:
+
+```bash
+# 1. Switch to aleph
+sudo su - aleph
+
+# 2. Check DISPLAY
+echo $DISPLAY  # Should show :0 or :1
+
+# 3. Test xclip
+echo test | xclip -selection clipboard
+xclip -o -selection clipboard
+
+# 4. Test Vim
+vim
+# Visual select text and press 'y'
+# It should copy to system clipboard
+```
+
+## Still Not Working?
+
+See the full documentation: [README.md](README.md)
+
+Or the complete fix guide: [ISSUE_3_X11_CLIPBOARD_FIX.md](../../ISSUE_3_X11_CLIPBOARD_FIX.md)
+

--- a/playbooks/roles/x11_auth/README.md
+++ b/playbooks/roles/x11_auth/README.md
@@ -1,0 +1,135 @@
+# X11 Authorization Role
+
+This role grants X server access to secondary users (like `aleph`) so they can run GUI applications and use clipboard features when switching users with `su` or `sudo su`.
+
+## Problem
+
+When you switch to a different user in a terminal session, the new user doesn't have permission to access the X server of the graphical session. This causes:
+
+- GUI applications fail with "Authorization required, but no authorization protocol specified"
+- Clipboard operations (like Vim `"+y` or `xclip`) fail with "Can't open display"
+- VSCode and other GUI apps won't launch
+
+## Solution
+
+This role automatically grants X server access to specified users using `xhost +si:localuser:<username>`, and makes this configuration persistent across reboots.
+
+## Requirements
+
+- A graphical desktop environment (X11 or XWayland)
+- `xhost` command (usually provided by `x11-xserver-utils` package)
+- `xclip` or `wl-clipboard` for clipboard operations
+
+## Role Variables
+
+Available variables with their default values:
+
+```yaml
+# List of users to grant X server access
+x11_auth_users:
+  - aleph
+
+# Whether to make the configuration persistent (auto-run on login)
+x11_auth_persistent: true
+
+# Primary user who owns the graphical session (auto-detected)
+x11_auth_primary_user: "{{ ansible_env.SUDO_USER | default(lookup('env', 'USER')) }}"
+```
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: x11_auth
+      vars:
+        x11_auth_users:
+          - aleph
+          - another_user
+      become: true
+```
+
+## How It Works
+
+The role implements multiple approaches to ensure persistence:
+
+1. **Immediate authorization**: Runs `xhost +si:localuser:<user>` immediately during playbook execution
+2. **Profile script**: Creates `/etc/profile.d/x11-auth-secondary-users.sh` to run on shell login
+3. **Systemd user service**: Creates a user service for graphical session startup
+
+## Usage
+
+After running this role:
+
+1. Switch to the secondary user:
+   ```bash
+   sudo su - aleph
+   ```
+
+2. Verify DISPLAY is set:
+   ```bash
+   echo $DISPLAY  # Should show something like ':0' or ':1'
+   ```
+
+3. Test clipboard:
+   ```bash
+   echo test | xclip -selection clipboard
+   xclip -o -selection clipboard
+   ```
+
+4. Use Vim with clipboard:
+   - Add `set clipboard=unnamedplus` to `~/.vimrc`
+   - Now `v` + `y` will copy to system clipboard
+
+## Troubleshooting
+
+### Still getting authorization errors?
+
+1. **Log out and back in**: The persistent configuration activates on graphical session start
+2. **Manual grant**: Run `xhost +si:localuser:aleph` as the graphical session owner
+3. **Check DISPLAY**: Run `echo $DISPLAY` - if empty, you're not in a graphical environment
+
+### Clipboard still not working?
+
+1. **Install clipboard tools**:
+   ```bash
+   sudo apt-get install -y xclip wl-clipboard vim-gtk3
+   ```
+
+2. **Configure Vim**: Add to `~/.vimrc`:
+   ```vim
+   set clipboard=unnamedplus
+   ```
+
+3. **Verify Vim has clipboard support**:
+   ```bash
+   vim --version | grep clipboard  # Should show +clipboard
+   ```
+
+### In tmux?
+
+Add to `~/.tmux.conf`:
+```tmux
+set -g set-clipboard on
+```
+
+## Security Note
+
+The `xhost +si:localuser:<username>` command only grants access to specific local users, not to any remote connections or arbitrary processes. This is a secure method for local user-to-user X server access.
+
+## Related Issues
+
+- [Issue #3: aleph user doesn't have permission for X server](https://github.com/gonzfe05/ansible/issues/3)
+
+## License
+
+MIT
+
+## Author
+
+gonzfe05
+

--- a/playbooks/roles/x11_auth/defaults/main.yml
+++ b/playbooks/roles/x11_auth/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# X11 authorization settings for secondary users
+x11_auth_users:
+  - aleph
+
+# Whether to add xhost command to graphical session startup
+x11_auth_persistent: true
+
+# Primary user who owns the graphical session (auto-detected if not set)
+x11_auth_primary_user: "{{ ansible_env.SUDO_USER | default(lookup('env', 'USER')) }}"
+

--- a/playbooks/roles/x11_auth/meta/main.yml
+++ b/playbooks/roles/x11_auth/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  author: gonzfe05
+  description: Grant X11 server access to secondary users for GUI apps and clipboard
+  company: Personal
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
+  galaxy_tags:
+    - x11
+    - xorg
+    - clipboard
+    - gui
+    - display
+
+dependencies: []
+

--- a/playbooks/roles/x11_auth/molecule/default/converge.yml
+++ b/playbooks/roles/x11_auth/molecule/default/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    x11_auth_users:
+      - testuser
+  tasks:
+    - name: Create test user
+      ansible.builtin.user:
+        name: testuser
+        state: present
+      become: true
+
+    - name: Include x11_auth role
+      ansible.builtin.include_role:
+        name: x11_auth
+

--- a/playbooks/roles/x11_auth/molecule/default/molecule.yml
+++ b/playbooks/roles/x11_auth/molecule/default/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+

--- a/playbooks/roles/x11_auth/molecule/default/verify.yml
+++ b/playbooks/roles/x11_auth/molecule/default/verify.yml
@@ -1,0 +1,24 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check if profile script exists
+      ansible.builtin.stat:
+        path: /etc/profile.d/x11-auth-secondary-users.sh
+      register: profile_script
+
+    - name: Assert profile script was created
+      ansible.builtin.assert:
+        that:
+          - profile_script.stat.exists
+          - profile_script.stat.mode == '0644'
+        fail_msg: "Profile script not created or has wrong permissions"
+        success_msg: "Profile script created successfully"
+
+    - name: Check profile script contains expected user
+      ansible.builtin.command:
+        cmd: grep -q "testuser" /etc/profile.d/x11-auth-secondary-users.sh
+      register: grep_result
+      failed_when: grep_result.rc != 0
+      changed_when: false
+

--- a/playbooks/roles/x11_auth/tasks/main.yml
+++ b/playbooks/roles/x11_auth/tasks/main.yml
@@ -1,0 +1,89 @@
+---
+# =============================================================================
+# X11 Authorization for Secondary Users
+# =============================================================================
+# This role grants X server access to secondary users (like 'aleph') so they
+# can run GUI applications and use clipboard features when switching users.
+#
+# Fixes issue: https://github.com/gonzfe05/ansible/issues/3
+# =============================================================================
+
+- name: Detect the primary graphical session user
+  ansible.builtin.set_fact:
+    primary_user: "{{ x11_auth_primary_user }}"
+  when: x11_auth_primary_user is defined
+
+- name: Get the user running the playbook (fallback)
+  ansible.builtin.command: whoami
+  register: whoami_result
+  changed_when: false
+  when: primary_user is not defined
+
+- name: Set primary_user from whoami
+  ansible.builtin.set_fact:
+    primary_user: "{{ whoami_result.stdout }}"
+  when: primary_user is not defined
+
+- name: Debug primary user
+  ansible.builtin.debug:
+    msg: "Primary graphical session user: {{ primary_user }}"
+
+- name: Check if running in a graphical session
+  ansible.builtin.command: loginctl show-session $(loginctl | grep {{ primary_user }} | awk '{print $1}' | head -n1) -p Type
+  register: session_type
+  ignore_errors: true
+  changed_when: false
+
+- name: Create X11 authorization script for graphical session startup
+  ansible.builtin.template:
+    src: x11-auth-secondary-users.sh.j2
+    dest: /etc/profile.d/x11-auth-secondary-users.sh
+    mode: '0644'
+    owner: root
+    group: root
+  become: true
+  when: x11_auth_persistent
+
+- name: Create systemd user service for X11 authorization (alternative method)
+  ansible.builtin.template:
+    src: x11-auth.service.j2
+    dest: "/home/{{ primary_user }}/.config/systemd/user/x11-auth.service"
+    mode: '0644'
+    owner: "{{ primary_user }}"
+    group: "{{ primary_user }}"
+  become: true
+  when: x11_auth_persistent
+
+- name: Ensure systemd user directory exists
+  ansible.builtin.file:
+    path: "/home/{{ primary_user }}/.config/systemd/user"
+    state: directory
+    mode: '0755'
+    owner: "{{ primary_user }}"
+    group: "{{ primary_user }}"
+  become: true
+  when: x11_auth_persistent
+
+- name: Grant X server access to secondary users (immediate)
+  ansible.builtin.command: "xhost +si:localuser:{{ item }}"
+  loop: "{{ x11_auth_users }}"
+  environment:
+    DISPLAY: "{{ ansible_env.DISPLAY | default(':0') }}"
+    XAUTHORITY: "{{ ansible_env.XAUTHORITY | default('/home/' + primary_user + '/.Xauthority') }}"
+  become: true
+  become_user: "{{ primary_user }}"
+  when: ansible_env.DISPLAY is defined
+  ignore_errors: true
+  changed_when: false
+
+- name: Display X11 authorization status
+  ansible.builtin.debug:
+    msg: |
+      X11 authorization configured for users: {{ x11_auth_users | join(', ') }}
+      
+      If you're still experiencing issues:
+      1. Log out and log back in to your graphical session
+      2. Manually run: xhost +si:localuser:{{ x11_auth_users[0] }}
+      3. Verify with: echo $DISPLAY (should not be empty)
+      4. Test clipboard: echo test | xclip -selection clipboard
+

--- a/playbooks/roles/x11_auth/templates/x11-auth-secondary-users.sh.j2
+++ b/playbooks/roles/x11_auth/templates/x11-auth-secondary-users.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+# {{ ansible_managed }}
+# X11 Authorization for Secondary Users
+# This script grants X server access to secondary users for GUI apps and clipboard
+
+# Only run in graphical sessions with DISPLAY set
+if [ -n "$DISPLAY" ]; then
+    # Grant access to secondary users
+{% for user in x11_auth_users %}
+    xhost +si:localuser:{{ user }} 2>/dev/null
+{% endfor %}
+fi
+

--- a/playbooks/roles/x11_auth/templates/x11-auth.service.j2
+++ b/playbooks/roles/x11_auth/templates/x11-auth.service.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Grant X11 access to secondary users
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+Environment="DISPLAY={{ ansible_env.DISPLAY | default(':0') }}"
+{% for user in x11_auth_users %}
+ExecStart=/usr/bin/xhost +si:localuser:{{ user }}
+{% endfor %}
+RemainAfterExit=yes
+
+[Install]
+WantedBy=graphical-session.target
+


### PR DESCRIPTION
- Introduced a new role `x11_auth` to grant X server access to secondary users, addressing clipboard and GUI application issues when switching users.
- Updated `after_format.yaml` to include the `x11_auth` role and necessary packages for clipboard support.
- Enhanced Vim and Neovim configurations for clipboard integration in the `env_setup` role.
- Created comprehensive documentation in `ISSUE_3_X11_CLIPBOARD_FIX.md` and related files for user guidance and troubleshooting.
- Implemented persistent X11 authorization through a profile script and systemd service for seamless user experience.